### PR TITLE
Added missing html loader, and private flag

### DIFF
--- a/webpack-demo/package.json
+++ b/webpack-demo/package.json
@@ -2,6 +2,7 @@
     "name": "webpack-demo",
     "version": "0.0.0",
     "description": "",
+    "private": true,
     "main": "webpack.config.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"
@@ -13,6 +14,7 @@
         "file-loader": "^0.8.4",
         "style-loader": "^0.12.2",
         "url-loader": "^0.5.6",
+        "html-loader" : "^0.3.0",
         "webpack-notifier": "^1.2.1"
     }
 }


### PR DESCRIPTION
npm shows a warning when there is no repository field, marked package
private. The html loader was missing, and prevented webpack -w from
working :)
